### PR TITLE
move gg certs into secrets manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,63 +91,15 @@ Once our devices get provisioned they will become part of this Thing Group allow
 aws iot create-thing-group --thing-group-name EmbeddedLinuxFleet
 ```
 
-##### put claim certificates in CodeCommit repo:
+##### put claim certificates in SecretsManager repo:
 ```bash
-aws codecommit put-file \
-    --repository-name ec2-ami-biga-layer-repo \
-    --branch-name main \
-    --file-content file://claim-certs/claim.cert.pem \
-    --file-path /claim.cert.pem \
-    --parent-commit-id $(aws codecommit get-branch --repository-name ec2-ami-biga-layer-repo --branch-name main --query 'branch.commitId' --output text) \
-    --commit-message "commit claim certificates" \
-    --cli-binary-format raw-in-base64-out
+aws secretsmanager create-secret --name EC2AMIBigaPipeline_claim.cert.pem --secret-binary fileb://claim-certs/claim.cert.pem
+aws secretsmanager create-secret --name EC2AMIBigaPipeline_claim.pkey.pem --secret-binary fileb://claim-certs/claim.pkey.pem
+aws secretsmanager create-secret --name EC2AMIBigaPipeline_claim.root.pem --secret-binary fileb://claim-certs/claim.root.pem
 
-aws codecommit put-file \
-    --repository-name ec2-ami-biga-layer-repo \
-    --branch-name main \
-    --file-content file://claim-certs/claim.pkey.pem \
-    --file-path /claim.pkey.pem \
-    --parent-commit-id $(aws codecommit get-branch --repository-name ec2-ami-biga-layer-repo --branch-name main --query 'branch.commitId' --output text) \
-    --commit-message "commit claim certificates" \
-    --cli-binary-format raw-in-base64-out
-
-
-aws codecommit put-file \
-    --repository-name ec2-ami-biga-layer-repo \
-    --branch-name main \
-    --file-content file://claim-certs/claim.root.pem \
-    --file-path /claim.root.pem  \
-    --parent-commit-id $(aws codecommit get-branch --repository-name ec2-ami-biga-layer-repo --branch-name main --query 'branch.commitId' --output text) \
-    --commit-message "commit claim certificates" \
-    --cli-binary-format raw-in-base64-out
-
-aws codecommit put-file \
-    --repository-name nxp-goldbox-biga-layer-repo \
-    --branch-name main \
-    --file-content file://claim-certs/claim.cert.pem \
-    --file-path /claim.cert.pem \
-    --parent-commit-id $(aws codecommit get-branch --repository-name nxp-goldbox-biga-layer-repo --branch-name main --query 'branch.commitId' --output text) \
-    --commit-message "commit claim certificates" \
-    --cli-binary-format raw-in-base64-out
-
-aws codecommit put-file \
-    --repository-name nxp-goldbox-biga-layer-repo \
-    --branch-name main \
-    --file-content file://claim-certs/claim.pkey.pem \
-    --file-path /claim.pkey.pem \
-    --parent-commit-id $(aws codecommit get-branch --repository-name nxp-goldbox-biga-layer-repo --branch-name main --query 'branch.commitId' --output text) \
-    --commit-message "commit claim certificates" \
-    --cli-binary-format raw-in-base64-out
-
-aws codecommit put-file \
-    --repository-name nxp-goldbox-biga-layer-repo \
-    --branch-name main \
-    --file-content file://claim-certs/claim.root.pem \
-    --file-path /claim.root.pem  \
-    --parent-commit-id $(aws codecommit get-branch --repository-name nxp-goldbox-biga-layer-repo --branch-name main --query 'branch.commitId' --output text) \
-    --commit-message "commit claim certificates" \
-    --cli-binary-format raw-in-base64-out
-
+aws secretsmanager create-secret --name NxpGoldboxBigaPipeline_claim.cert.pem --secret-binary fileb://claim-certs/claim.cert.pem
+aws secretsmanager create-secret --name NxpGoldboxBigaPipeline_claim.pkey.pem --secret-binary fileb://claim-certs/claim.pkey.pem
+aws secretsmanager create-secret --name NxpGoldboxBigaPipeline_claim.root.pem --secret-binary fileb://claim-certs/claim.root.pem
 ```
 
 #### seed repo with site.conf:
@@ -310,9 +262,6 @@ Third, we need a security group (to allow ssh access later on)
 ```
 aws ec2 create-security-group --group-name bigaSG --description "a default sg for biga"
 aws ec2 authorize-security-group-ingress --group-id <security_group_id>  --protocol tcp  --port 22  --cidr 0.0.0.0/0
-
-
-
 ```
 If you already created it, you can find the security_group_id this way:
 ```

--- a/cdk/bin/poky-pipeline.ts
+++ b/cdk/bin/poky-pipeline.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import * as cdk from "aws-cdk-lib";
+import {Secret} from "aws-cdk-lib/aws-secretsmanager";
 import {
   EmbeddedLinuxPipelineStack,
   BuildImageDataStack,
@@ -9,6 +10,18 @@ import {
   ImageKind,
   ProjectKind,
 } from "aws4embeddedlinux-cdk-lib";
+import {
+  AccountPrincipal,
+  ArnPrincipal,
+  Effect,
+  IRole,
+  ManagedPolicy,
+  Policy,
+  PolicyDocument,
+  PolicyStatement,
+  Role,
+  ServicePrincipal
+} from "aws-cdk-lib/aws-iam";
 import * as path from 'path';
 
 const app = new cdk.App();
@@ -63,6 +76,14 @@ new EmbeddedLinuxPipelineStack(app, "EC2AMIBigaPipeline", {
   imageRepo: buildImageRepo.repository,
   imageTag: ImageKind.Ubuntu22_04,
   vpc: vpc.vpc,
+  buildPolicyAdditions: [
+    PolicyStatement.fromJson({
+      Effect: "Allow",
+      Action: "secretsmanager:GetSecretValue",
+      Resource:
+      `arn:aws:secretsmanager:${env.region}:${env.account}:secret:EC2AMIBigaPipeline*`,
+    }),
+  ],
   layerRepoName: "ec2-ami-biga-layer-repo",
   projectKind: ProjectKind.PokyAmi,
 });
@@ -75,6 +96,14 @@ new EmbeddedLinuxPipelineStack(app, "NxpGoldboxBigaPipeline", {
   imageRepo: buildImageRepo.repository,
   imageTag: ImageKind.Ubuntu22_04,
   vpc: vpc.vpc,
+  buildPolicyAdditions: [
+    PolicyStatement.fromJson({
+      Effect: "Allow",
+      Action: "secretsmanager:GetSecretValue",
+      Resource:
+      `arn:aws:secretsmanager:${env.region}:${env.account}:secret:NxpGoldboxBigaPipeline*`,
+    }),
+  ],
   layerRepoName: "nxp-goldbox-biga-layer-repo",
   projectKind: ProjectKind.MetaAwsDemo,
 });

--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "meta-aws-cdk-pipeline-reference",
+  "name": "demo-iot-automotive-embeddedlinux-image-pipeline",
   "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "meta-aws-cdk-pipeline-reference",
+      "name": "demo-iot-automotive-embeddedlinux-image-pipeline",
       "version": "0.1.0",
       "dependencies": {
         "aws4embeddedlinux-cdk-lib": "aws4embeddedlinux/aws4embeddedlinux-ci",
@@ -2141,8 +2141,8 @@
       }
     },
     "node_modules/aws4embeddedlinux-cdk-lib": {
-      "version": "0.1.2",
-      "resolved": "git+ssh://git@github.com/aws4embeddedlinux/aws4embeddedlinux-ci.git#15aa7c5c329203bc3a10abcb811dedb02f001790",
+      "version": "0.1.3",
+      "resolved": "git+ssh://git@github.com/aws4embeddedlinux/aws4embeddedlinux-ci.git#45f22e421b3ec9b5f911d715a2058a1b1a2b5e96",
       "peerDependencies": {
         "aws-cdk-lib": "^2.86.0",
         "constructs": "^10.0.0"
@@ -7088,7 +7088,7 @@
       }
     },
     "aws4embeddedlinux-cdk-lib": {
-      "version": "git+ssh://git@github.com/aws4embeddedlinux/aws4embeddedlinux-ci.git#15aa7c5c329203bc3a10abcb811dedb02f001790",
+      "version": "git+ssh://git@github.com/aws4embeddedlinux/aws4embeddedlinux-ci.git#45f22e421b3ec9b5f911d715a2058a1b1a2b5e96",
       "from": "aws4embeddedlinux-cdk-lib@aws4embeddedlinux/aws4embeddedlinux-ci",
       "requires": {}
     },

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "meta-aws-cdk-pipeline-reference",
+  "name": "demo-iot-automotive-embeddedlinux-image-pipeline",
   "version": "0.1.0",
   "bin": {
     "demos-pipeline": "bin/poky-pipeline.js"

--- a/cdk/repo_seed/ami/build.buildspec.yml
+++ b/cdk/repo_seed/ami/build.buildspec.yml
@@ -22,8 +22,10 @@ phases:
       - source meta-agl/scripts/aglsetup.sh  -f -m biga-ec2 -b $TMP_DIR
       - echo copy site.conf
       - cp $CODEBUILD_SRC_DIR/site.conf $TMP_DIR/conf/
-      - echo copy claim certs
-      - cp $CODEBUILD_SRC_DIR/claim.cert.pem $CODEBUILD_SRC_DIR/claim.pkey.pem $CODEBUILD_SRC_DIR/claim.root.pem $CODEBUILD_SRC_DIR/external/meta-aws/recipes-iot/aws-iot-greengrass/files/
+      - echo get claim certs
+      - aws secretsmanager get-secret-value --secret-id EC2AMIBigaPipeline_claim.cert.pem --query SecretBinary --output text | base64 --decode > $CODEBUILD_SRC_DIR/external/meta-aws/recipes-iot/aws-iot-greengrass/files/claim.cert.pem
+      - aws secretsmanager get-secret-value --secret-id EC2AMIBigaPipeline_claim.cert.pem --query SecretBinary --output text | base64 --decode > $CODEBUILD_SRC_DIR/external/meta-aws/recipes-iot/aws-iot-greengrass/files/claim.pkey.pem
+      - aws secretsmanager get-secret-value --secret-id EC2AMIBigaPipeline_claim.cert.pem --query SecretBinary --output text | base64 --decode > $CODEBUILD_SRC_DIR/external/meta-aws/recipes-iot/aws-iot-greengrass/files/claim.root.pem
       - echo build started at `date`
       - bitbake  aws-biga-image
       - bitbake  aws-biga-image -c populate_sdk

--- a/cdk/repo_seed/device/build.buildspec.yml
+++ b/cdk/repo_seed/device/build.buildspec.yml
@@ -22,8 +22,10 @@ phases:
       - source meta-agl/scripts/aglsetup.sh  -f -m biga-goldbox -b $TMP_DIR
       - echo copy site.conf
       - cp $CODEBUILD_SRC_DIR/site.conf $TMP_DIR/conf/
-      - echo copy claim certs
-      - cp $CODEBUILD_SRC_DIR/claim.cert.pem $CODEBUILD_SRC_DIR/claim.pkey.pem $CODEBUILD_SRC_DIR/claim.root.pem $CODEBUILD_SRC_DIR/external/meta-aws/recipes-iot/aws-iot-greengrass/files/
+      - echo get claim certs
+      - aws secretsmanager get-secret-value --secret-id NxpGoldboxBigaPipeline_claim.cert.pem --query SecretBinary --output text | base64 --decode > $CODEBUILD_SRC_DIR/external/meta-aws/recipes-iot/aws-iot-greengrass/files/claim.cert.pem
+      - aws secretsmanager get-secret-value --secret-id NxpGoldboxBigaPipeline_claim.pkey.pem --query SecretBinary --output text | base64 --decode > $CODEBUILD_SRC_DIR/external/meta-aws/recipes-iot/aws-iot-greengrass/files/claim.pkey.pem
+      - aws secretsmanager get-secret-value --secret-id NxpGoldboxBigaPipeline_claim.root.pem --query SecretBinary --output text | base64 --decode > $CODEBUILD_SRC_DIR/external/meta-aws/recipes-iot/aws-iot-greengrass/files/claim.root.pem
       - echo build started at `date`
       - bitbake  aws-biga-image
       - bitbake  aws-biga-image -c populate_sdk


### PR DESCRIPTION
putting gg certs into secrets manager, for this permissions must be granted. This is planned to add as a feature to https://github.com/aws4embeddedlinux/aws4embeddedlinux-ci